### PR TITLE
Fixes for resolution service

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -22,9 +22,9 @@ env = 'dev'
 # dependencies if apply
 url_registry_db = ""
 url_accounts = "https://localhost:8006"
-url_auth = ""
+url_auth = "https://localhost:8007"
 url_identity = ""
-url_index = ""
+url_index = "https://localhost:8002"
 url_onboarding = ""
 url_repository = ""
 url_transformation = ""

--- a/resolution/controllers/hub_key_handler.py
+++ b/resolution/controllers/hub_key_handler.py
@@ -146,14 +146,20 @@ def resolve_link_id_type(reference_links, parsed_key):
     if not _link_for_id_type:
         raise Return(None)
 
+    if '{source_id}' not in _link_for_id_type:
+        raise Return(_link_for_id_type)
+
     if "id_type" in parsed_key:
         # s0 key
-        repo_ids = yield _get_repos_for_source_id(parsed_key['id_type'], parsed_key['entity_id'])
-        source_ids = []
+        if parsed_key['id_type'] == redirect_id_type:
+            source_ids = [{'source_id_type': parsed_key['id_type'], 'source_id': parsed_key['entity_id']}]
+        else:
+            repo_ids = yield _get_repos_for_source_id(parsed_key['id_type'], parsed_key['entity_id'])
+            source_ids = []
 
-        for repo in repo_ids:
-            partial_source_ids = yield _get_ids(repo['repository_id'], repo['entity_id'])
-            source_ids += partial_source_ids
+            for repo in repo_ids:
+                partial_source_ids = yield _get_ids(repo['repository_id'], repo['entity_id'])
+                source_ids += partial_source_ids
     else:
         # s1 key
         source_ids = yield _get_ids(parsed_key['repository_id'], parsed_key['entity_id'])

--- a/tests/unit/controllers/test_hub_key_handler.py
+++ b/tests/unit/controllers/test_hub_key_handler.py
@@ -128,10 +128,27 @@ def test_resolve_link_id_type_empty_ref_no_links2():
     assert res is None
 
 
+@gen_test
+def test_resolve_link_no_source_id():
+    res = yield hub_key_handler.resolve_link_id_type({'redirect_id_type': 'testidtype',
+                                                      'links': {'testidtype': 'http://example.com'}},
+                                                     {'id_type': 'otheridtype', 'entity_id': '321a23'})
+    assert res == 'http://example.com'
+
+
+@gen_test
+def test_resolve_link_id_in_s0_hk():
+    res = yield hub_key_handler.resolve_link_id_type({'redirect_id_type': 'testidtype',
+                                                      'links': {'testidtype': 'http://test/{source_id}'}},
+                                                     {'id_type': 'testidtype', 'entity_id': '321a23'})
+    assert res is not None
+    assert res == 'http://test/321a23'
+
+
 @patch('resolution.controllers.hub_key_handler._get_ids')
 @patch('resolution.controllers.hub_key_handler._get_repos_for_source_id')
 @gen_test
-def test_resolve_link_id_hk_s0(_get_repos_for_source_id, _get_ids):
+def test_resolve_link_id_not_in_s0_hk(_get_repos_for_source_id, _get_ids):
     _get_repos_for_source_id.return_value = make_future([{'repository_id': '043023143124', 'entity_id': '0102343434'}])
     _get_ids.return_value = make_future([{'source_id_type': 'testidtype', 'source_id': 'this id has spaces and ?'}])
     res = yield hub_key_handler.resolve_link_id_type({'redirect_id_type': 'testidtype',
@@ -140,9 +157,10 @@ def test_resolve_link_id_hk_s0(_get_repos_for_source_id, _get_ids):
     assert res is not None
     assert res == 'http://test/this+id+has+spaces+and+%3F'
 
+
 @patch('resolution.controllers.hub_key_handler._get_ids')
 @gen_test
-def test_resolve_link_id_hk_s1(_get_ids):
+def test_resolve_link_s1_hk(_get_ids):
     _get_ids.return_value = make_future([{'source_id_type': 'testidtype', 'source_id': 'this id has spaces and ?'}])
     res = yield hub_key_handler.resolve_link_id_type({'redirect_id_type': 'testidtype',
                                                       'links': {'testidtype': 'http://test/{source_id}'}}, {


### PR DESCRIPTION
If redirect url does not have source_id do not look up ids for assets. Use s0 embedded source id where possible

Bamboo job: http://bamboo.digicat.io/browse/CHCL-MPT180
